### PR TITLE
feat: forward necessary cloudevents headers to nats

### DIFF
--- a/pkg/channel/jetstream/dispatcher/dispatcher.go
+++ b/pkg/channel/jetstream/dispatcher/dispatcher.go
@@ -372,6 +372,7 @@ func (d *Dispatcher) messageReceiver(ctx context.Context, ch eventingchannels.Ch
         Data:    writer.Bytes(),
         Subject: subject,
         Header: nats.Header{
+            "ce-id": []string{string(eventID)},
             "Nats-Msg-Id": []string{string(eventID)}, 
             "ce-specversion": []string{string(eventSpecVersion)},
             "ce-source": []string{string(eventSource)},

--- a/pkg/common/cloudevents/transformer.go
+++ b/pkg/common/cloudevents/transformer.go
@@ -27,6 +27,8 @@ import (
 type IDExtractorTransformer string
 type SourceExtractorTransformer string
 type SubjectExtractorTransformer string
+type TypeExtractorTransformer string
+type SpecVersionExtractorTransformer string
 
 func (a *IDExtractorTransformer) Transform(reader binding.MessageMetadataReader, _ binding.MessageMetadataWriter) error {
 	_, ty := reader.GetAttribute(spec.ID)
@@ -66,3 +68,31 @@ func (a *SubjectExtractorTransformer) Transform(reader binding.MessageMetadataRe
 
 	return nil
 }
+
+func (a *TypeExtractorTransformer) Transform(reader binding.MessageMetadataReader, _ binding.MessageMetadataWriter) error {
+	_, ty := reader.GetAttribute(spec.Type)
+	if ty != nil {
+		tyParsed, err := types.ToString(ty)
+		if err != nil {
+			return err
+		}
+		*a = TypeExtractorTransformer(tyParsed)
+	}
+
+	return nil
+}
+
+func (a *SpecVersionExtractorTransformer) Transform(reader binding.MessageMetadataReader, _ binding.MessageMetadataWriter) error {
+	_, ty := reader.GetAttribute(spec.SpecVersion)
+	if ty != nil {
+		tyParsed, err := types.ToString(ty)
+		if err != nil {
+			return err
+		}
+		*a = SpecVersionExtractorTransformer(tyParsed)
+	}
+
+	return nil
+}
+
+


### PR DESCRIPTION
```
[#5] Received on "user-pion.mindwm-stg1-broker-kne-trigger._knative" with reply "_INBOX.T20zWQqD09HufntkQo7sVD.WnaZ4Lgu"
ce-type: org.mindwm.v1.pong
Nats-Msg-Id: 05edfb90ebf6441e9950ef5f1aaae5d1
ce-source: org.mindwm.cyan.knfunc.pong
ce-specversion: 1.0
ce-subject: org.mindwm.pion.mindwm-stg1.tmux.L3Zhci90bXV4L21pbmR3bQ==.d25adafe-1622-3e32-1bb0-f82c567983c6.0.0
ce-traceparent: 00-ff9574599a6476d637907e707677c5cf-920c4cbc12baa7ca-01

{"type":"org.mindwm.v1.pong","uuid":"25afcc164e1b49fca297ae41e1056045"}
```